### PR TITLE
Masternode should not take fee from miner block fee

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1489,7 +1489,8 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
 //ANON
 CAmount GetMasternodePayment(int nHeight, CAmount blockValue)
 {
-    CAmount ret = blockValue*0.35; // Masternode should get payed only 35% of the block reward
+    // Masternode should get paid only 35% of the block reward, and Masternode should NOT take any of the miners fee
+    CAmount ret = 0.35 * GetBlockSubsidy(nHeight, Params().GetConsensus());
     int nMNPIBlock = Params().GetConsensus().nMasternodePaymentsIncreaseBlock;
     int nMNPIPeriod = Params().GetConsensus().nMasternodePaymentsIncreasePeriod;
 


### PR DESCRIPTION
Masternodes can only take 35% of the block reward, they are NOT entitled to any of the miner fee. This PR fixes a bug that allowed MN to take some miner fee. 