### PR TITLE
Require masternode sync before getblocktemplate rpc command, and before local miner can begin hashing blocks

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -889,7 +889,7 @@ void static BitcoinMiner()
                         LOCK(cs_vNodes);
                         fvNodesEmpty = vNodes.empty();
                     }
-                    if (!fvNodesEmpty && (fForkMiner || !IsInitialBlockDownload(true)))
+                    if (!fvNodesEmpty && (fForkMiner || !IsInitialBlockDownload(true)) && masternodeSync.IsSynced())
                         break;
                     MilliSleep(1000);
                 } while (true);

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -596,6 +596,9 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     if (IsInitialBlockDownload())
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "ANON is downloading blocks...");
 
+    if (!masternodeSync.IsSynced())
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "ANON is syncing with network...");        
+
     static unsigned int nTransactionsUpdatedLast;
 
     if (!lpval.isNull())


### PR DESCRIPTION
This PR requires the miner to be fully synced with the network before submitting blocks. This should solve miners submitting blocks before knowing the status of masternodes.