### PR TITLE
Remove dead seeders from mainnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -101,13 +101,9 @@ public:
         vSeeds.push_back(CDNSSeedData("anon1-mainnet", "149.28.224.254"));
         vSeeds.push_back(CDNSSeedData("anon2-mainnet", "108.61.159.183"));
         vSeeds.push_back(CDNSSeedData("anon3-mainnet", "139.162.88.43"));
-        vSeeds.push_back(CDNSSeedData("anon4-mainnet", "139.162.96.172"));
         vSeeds.push_back(CDNSSeedData("anon5-mainnet", "172.104.185.21"));
-        vSeeds.push_back(CDNSSeedData("anon6-mainnet", "172.104.175.135"));
         vSeeds.push_back(CDNSSeedData("anon7-mainnet", "139.162.180.228"));
-        vSeeds.push_back(CDNSSeedData("anon8-mainnet", "139.162.184.130"));
         vSeeds.push_back(CDNSSeedData("anon9-mainnet", "72.14.184.145"));
-        vSeeds.push_back(CDNSSeedData("anon10-mainnet", "198.58.96.134"));
         vSeeds.push_back(CDNSSeedData("anon11-mainnet", "149.202.74.156 "));
         vSeeds.push_back(CDNSSeedData("anon12-mainnet", "91.121.69.100"));
         vSeeds.push_back(CDNSSeedData("anon13-mainnet", "45.76.241.37"));


### PR DESCRIPTION
This PR will remove seeder nodes that are no longer active. 