### PR TITLE
V1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.com/ByeBugDevelopment/anon-backup.svg?token=WBBgtRXJbdCRsjxqqhJy&branch=master)](https://travis-ci.com/ByeBugDevelopment/anon-backup)
 
-**Anonymous Bitcoin v.1.2.0**
+**Anonymous Bitcoin v.1.3.0**
 
 ANON is an implementation of the zerocash protocol, bootstrapped with a merge of the Official Bitcoin and Zclassic UTXO sets via a snapshot and airdrop, and with the additional implementation of masternodes.
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -128,17 +128,6 @@ public:
         vSeeds.push_back(CDNSSeedData("anon20-mainnet", "207.246.95.8"));
                 
 
-
-
-
-
-
-
-
-
-
-
-
         // guarantees the first 2 characters, when base58 encoded, are "An"
         base58Prefixes[PUBKEY_ADDRESS]     = {0x05,0x82};
 
@@ -207,7 +196,7 @@ public:
 
         consensus.prePowLimit = consensus.powLimit;
         assert(maxUint/UintToArith256(consensus.powLimit) >= consensus.nPowAveragingWindow);
-        consensus.fPowAllowMinDifficultyBlocks = true;
+        consensus.fPowAllowMinDifficultyBlocks = false;
 
         consensus.nRuleChangeActivationThreshold = 1512; // 75% for testchains
         consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
@@ -216,15 +205,15 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008
 
-        pchMessageStart[0] = 0xa3;
-        pchMessageStart[1] = 0x45;
+        pchMessageStart[0] = 0xd3;
+        pchMessageStart[1] = 0xf4;
         pchMessageStart[2] = 0xf3;
-        pchMessageStart[3] = 0x69;
+        pchMessageStart[3] = 0x77;
         
         eh_epoch_1 = eh200_9;
         eh_epoch_2 = eh144_5;
-        eh_epoch_1_endblock = nForkStartHeight + nForkHeightRange;
-        eh_epoch_2_startblock = nForkStartHeight + nForkHeightRange;
+        eh_epoch_1_endblock = nForkStartHeight + nForkHeightRange + 999999998;
+        eh_epoch_2_startblock = nForkStartHeight + nForkHeightRange + 999999999;
 
 
         vAlertPubKey = ParseHex("048679fb891b15d0cada9692047fd0ae26ad8bfb83fabddbb50334ee5bc0683294deb410be20513c5af6e7b9cec717ade82b27080ee6ef9a245c36a795ab044bb3");
@@ -233,15 +222,21 @@ public:
 
 
         //! Modify the testnet genesis block so the timestamp is valid for a later start.
-        genesis.nTime = 1536537600;
+        genesis.nTime = 1537347600;
         genesis.nBits = 0x2007ffff;
-        genesis.nNonce = uint256S("0x000000000000000000000000000000000000000000000000000000000000000d");
-        genesis.nSolution = ParseHex("00dd8d3ec1f1f3a07e3baf9a4106a790c880a96a92a76066a4046e9b1e3a995d383e7bf55593cfd9db6e4dcb06029d8db0030b22ce0627265c6d775fc2013409ef9441e7d54275b6bc67e92170c671d31b634a5559a41486bb28a79236e7c9038bf60c66");
+        genesis.nNonce = uint256S("0x000000000000000000000000000000000000000000000000000000000000000f");
+        genesis.nSolution = ParseHex("1a2a4e95433a1db4889ae7a5883d8e665ec2923e14876bbb902ccf3d7d5bd19da42bfc0d92a5fab90bab8542157c2d35fe6226922d41f060e6439a934781c599eef63c0dd6e6be2fded32e61296eb311211a25253f15bda68b9844794432bcd473717655");
         consensus.hashGenesisBlock = genesis.GetHash();
-        assert(consensus.hashGenesisBlock == uint256S("0x0411c719ec9d99ce6188074ab174f499d38a8bb009eecec0602e8edd0e55dcfa"));
+        assert(consensus.hashGenesisBlock == uint256S("0x07d2dd91f13803386aa0c05afd2adfcc6f911c5571a330a1118f6a0b3e0b2073"));
 
         vFixedSeeds.clear();
         vSeeds.clear();
+
+        vSeeds.push_back(CDNSSeedData("testnet_node1", "198.58.97.186"));
+        vSeeds.push_back(CDNSSeedData("testnet_node2", "45.33.13.94"));
+        vSeeds.push_back(CDNSSeedData("testnet_node3", "45.56.69.11"));
+        vSeeds.push_back(CDNSSeedData("testnet_node4", "96.126.120.121"));
+        vSeeds.push_back(CDNSSeedData("testnet_node5", "69.164.195.11"));
 
 
         // guarantees the first 2 characters, when base58 encoded, are "tA"
@@ -260,7 +255,7 @@ public:
 
         vFixedSeeds = std::vector<SeedSpec6>(pnSeed6_test, pnSeed6_test + ARRAYLEN(pnSeed6_test));
 
-        fMiningRequiresPeers = true;
+        fMiningRequiresPeers = false;
         fDefaultConsistencyChecks = false;
         fRequireStandard = true;
         fMineBlocksOnDemand = false;
@@ -275,10 +270,10 @@ public:
             0
         };
 
-        nForkStartHeight = 0;
-        nForkHeightRange = 0;
-        nZtransparentStartBlock = 0;
-        nZshieldedStartBlock = 0;
+        nForkStartHeight = 2;
+        nForkHeightRange = 1;
+        nZtransparentStartBlock = 5;
+        nZshieldedStartBlock = 6;
     }
 };
 static CTestNetParams testNetParams;

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -18,7 +18,7 @@ static const int MASTERNODE_CHECK_SECONDS               =   5;
 static const int MASTERNODE_MIN_MNB_SECONDS             =   5 * 60;
 static const int MASTERNODE_MIN_MNP_SECONDS             =  10 * 60;
 static const int MASTERNODE_EXPIRATION_SECONDS          =  65 * 60;
-static const int MASTERNODE_WATCHDOG_MAX_SECONDS        = 120 * 60;
+static const int MASTERNODE_WATCHDOG_MAX_SECONDS        = 4 * 120 * 60;
 static const int MASTERNODE_NEW_START_REQUIRED_SECONDS  = 180 * 60;
 
 static const int MASTERNODE_POSE_BAN_MAX_SCORE          = 5;

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -811,8 +811,13 @@ std::vector<std::pair<int, CMasternode>> CMasternodeMan::GetMasternodeRanks(int 
     BOOST_FOREACH (CMasternode &mn, vMasternodes)
     {
 
-        if (mn.nProtocolVersion < nMinProtocol || !mn.IsEnabled())
+        if (mn.nProtocolVersion < nMinProtocol)
             continue;
+        
+        if (!mn.IsEnabled()) {
+            vecMasternodeScores.push_back(std::make_pair(-1, &mn));
+            continue;
+        }
 
         int64_t nScore = mn.CalculateScore(blockHash).GetCompact(false);
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -811,13 +811,8 @@ std::vector<std::pair<int, CMasternode>> CMasternodeMan::GetMasternodeRanks(int 
     BOOST_FOREACH (CMasternode &mn, vMasternodes)
     {
 
-        if (mn.nProtocolVersion < nMinProtocol)
+        if (mn.nProtocolVersion < nMinProtocol || !mn.IsEnabled())
             continue;
-        
-        if (!mn.IsEnabled()) {
-            vecMasternodeScores.push_back(std::make_pair(-1, &mn));
-            continue;
-        }
 
         int64_t nScore = mn.CalculateScore(blockHash).GetCompact(false);
 

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -107,7 +107,7 @@ class CMasternodeMan
 
     static const int LAST_PAID_SCAN_BLOCKS = 100;
 
-    static const int MIN_POSE_PROTO_VERSION = 70203;
+    static const int MIN_POSE_PROTO_VERSION = 180003;
     static const int MAX_POSE_CONNECTIONS = 10;
     static const int MAX_POSE_RANK = 10;
     static const int MAX_POSE_BLOCKS = 10;

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -347,13 +347,15 @@ static const CRPCCommand vRPCCommands[] =
 #endif
 
         /* Dash features */
+        {"dash", "listmasternodes", &listmasternodes, true},
+        {"dash", "listmasternodeconf", &listmasternodeconf, true},
         {"dash", "masternode", &masternode, true},
         {"dash", "masternodelist", &masternodelist, true},
         {"dash", "masternodebroadcast", &masternodebroadcast, true},
         {"dash", "gobject", &gobject, true},
         {"dash", "mnsync", &mnsync, true},
-        { "dash",               "getgovernanceinfo",      &getgovernanceinfo,      true  },
-        { "dash",               "voteraw",                &voteraw,                true  },
+        {"dash", "getgovernanceinfo", &getgovernanceinfo, true},
+        {"dash", "voteraw", &voteraw, true},
         // {"dash", "getpoolinfo", &getpoolinfo, true},
 
 #ifdef ENABLE_WALLET

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -292,6 +292,8 @@ extern UniValue getspentinfo(const UniValue& params, bool fHelp);
 // extern UniValue privatesend(const UniValue& params, bool fHelp);
 // extern UniValue getpoolinfo(const UniValue& params, bool fHelp);
 // extern UniValue spork(const UniValue& params, bool fHelp);
+extern UniValue listmasternodes(const UniValue& params, bool fHelp);
+extern UniValue listmasternodeconf(const UniValue& params, bool fHelp);
 extern UniValue masternode(const UniValue& params, bool fHelp);
 extern UniValue masternodelist(const UniValue& params, bool fHelp);
 extern UniValue masternodebroadcast(const UniValue& params, bool fHelp);

--- a/src/sendalert.cpp
+++ b/src/sendalert.cpp
@@ -78,9 +78,10 @@ void ThreadSendAlert()
     alert.nCancel       = 1001;  // cancels previous messages up to this ID number
 
     // These versions are protocol versions
-    // 170002 : 1.0.0
-    alert.nMinVer       = 170002;
-    alert.nMaxVer       = 180004;
+    // 180004 : 1.0.0
+    // 180005 : 1.2.0
+    alert.nMinVer       = 180004;
+    alert.nMaxVer       = 180005;
 
     //
     // main.cpp:

--- a/src/version.h
+++ b/src/version.h
@@ -9,7 +9,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 180004;
+static const int PROTOCOL_VERSION = 180005;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -18,7 +18,7 @@ static const int INIT_PROTO_VERSION = 209;
 static const int GETHEADERS_VERSION = 31800;
 
 //! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 180003;
+static const int MIN_PEER_PROTO_VERSION = 180004;
 
 //! nTime field added to CAddress, starting with this version;
 //! if possible, avoid requesting addresses nodes older than this


### PR DESCRIPTION
This update includes:

## 1. New TESTNET 3.0.
Block explorer:
https://texplorer.anonfork.io/insight
 
The new TESTNET mimics current MAINNET except the following:
  - Proof of Work (Equihash 200,9).
  - No airdropped coins.
  - Pre-mined 30 million TESTNET coins for the upcoming TESTNET faucet.
  Note: If Anon Testnet faucet is down, or you need large amounts of coins to test you can contact @Calypso or any other core devs at [anon discord channel.](https://discordapp.com/channels/434507161305874433/440340571005911050)
## 2. Update protocol version.
 - Change the latest protocol version to 180005.
 - Change the minimum protocol version to 180004.

Note: Anytime the protocol changes you must rebroadcast/restart your masternode (start-alias or start-all from your wallet, make sure your wallet has new protocol too). Keep in mind, when you rebroadcast your masternode it may get moved down in the masternodes ranking list (in some cases). 
###### ! Protocol 180004 will be discontinued soon. We advise to update your masternode now, in order to not miss masternode payments once procotol 180004 is discontinued.

## 3. New RPC commands.
     "listmasternodes" & "listmasternodeconf"
 - ```listmasternodes ->``` returns a list of all known masternodes as an array of objects in JSON format with the following keys: 
[ { rank, network, ip, txhash, outidx, status, addr, version, lastseen, activetime, lastpaid } ].
- ```listmasternodeconf ->``` returns a list of all masternodes that are in the masternode.conf file, in JSON format with the following keys: 
[ { alias, address, privateKey, txHash, outputIndex, status, addr } ].
## 4. Minor improvements regarding watchdog.
 - Increast watchdog expiration time

 