### PR TITLE
Discontinue old protocol 180005

### DIFF
--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -23,8 +23,8 @@ class CGovernanceObject;
 class CGovernanceVote;
 
 static const int MAX_GOVERNANCE_OBJECT_DATA_SIZE = 16 * 1024;
-static const int MIN_GOVERNANCE_PEER_PROTO_VERSION = 180005;
-static const int GOVERNANCE_FILTER_PROTO_VERSION = 180005;
+static const int MIN_GOVERNANCE_PEER_PROTO_VERSION = 180006;
+static const int GOVERNANCE_FILTER_PROTO_VERSION = 180006;
 
 static const double GOVERNANCE_FILTER_FP_RATE = 0.001;
 

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -107,7 +107,7 @@ class CMasternodeMan
 
     static const int LAST_PAID_SCAN_BLOCKS = 100;
 
-    static const int MIN_POSE_PROTO_VERSION = 180005;
+    static const int MIN_POSE_PROTO_VERSION = 180006;
     static const int MAX_POSE_CONNECTIONS = 10;
     static const int MAX_POSE_RANK = 10;
     static const int MAX_POSE_BLOCKS = 10;

--- a/src/sendalert.cpp
+++ b/src/sendalert.cpp
@@ -80,8 +80,9 @@ void ThreadSendAlert()
     // These versions are protocol versions
     // 180004 : 1.0.0
     // 180005 : 1.2.0
-    alert.nMinVer       = 180004;
-    alert.nMaxVer       = 180005;
+    // 180006 : 2.0.0
+    alert.nMinVer       = 180006;
+    alert.nMaxVer       = 180007;
 
     //
     // main.cpp:

--- a/src/version.h
+++ b/src/version.h
@@ -18,7 +18,7 @@ static const int INIT_PROTO_VERSION = 209;
 static const int GETHEADERS_VERSION = 31800;
 
 //! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 180005;
+static const int MIN_PEER_PROTO_VERSION = 180006;
 
 //! nTime field added to CAddress, starting with this version;
 //! if possible, avoid requesting addresses nodes older than this


### PR DESCRIPTION
Nodes with current 180006 protocol will no longer be accepting connections from nodes with protocol <= 180005.