### PR TITLE
V2/invalidate chain

### DIFF
--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -23,8 +23,8 @@ class CGovernanceObject;
 class CGovernanceVote;
 
 static const int MAX_GOVERNANCE_OBJECT_DATA_SIZE = 16 * 1024;
-static const int MIN_GOVERNANCE_PEER_PROTO_VERSION = 180006;
-static const int GOVERNANCE_FILTER_PROTO_VERSION = 180006;
+static const int MIN_GOVERNANCE_PEER_PROTO_VERSION = 180007;
+static const int GOVERNANCE_FILTER_PROTO_VERSION = 180007;
 
 static const double GOVERNANCE_FILTER_FP_RATE = 0.001;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3643,6 +3643,12 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
         if (pcheckpoint && nHeight < pcheckpoint->nHeight)
             return state.DoS(100, error("%s: forked chain older than last checkpoint (height %d)", __func__, nHeight));
     }
+    // TEMP SOLUTION
+    if (nHeight == 38404) {
+        if (block.GetHash().ToString() != "0000003e14aed8597b83880b4e4b46002a548b33904a1b415b51a746aee467c0")
+        return state.DoS(100, error("%s: invalid forked chain", __func__),
+                         REJECT_INVALID, "bad-chain");
+    }
 
     // Reject block.nVersion < 4 blocks
     if (block.nVersion < 4)

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -107,7 +107,7 @@ class CMasternodeMan
 
     static const int LAST_PAID_SCAN_BLOCKS = 100;
 
-    static const int MIN_POSE_PROTO_VERSION = 180006;
+    static const int MIN_POSE_PROTO_VERSION = 180007;
     static const int MAX_POSE_CONNECTIONS = 10;
     static const int MAX_POSE_RANK = 10;
     static const int MAX_POSE_BLOCKS = 10;

--- a/src/sendalert.cpp
+++ b/src/sendalert.cpp
@@ -82,7 +82,7 @@ void ThreadSendAlert()
     // 180005 : 1.2.0
     // 180006 : 2.0.0
     // 180007 : 2.1.0
-    alert.nMinVer       = 180006;
+    alert.nMinVer       = 180007;
     alert.nMaxVer       = 180008;
 
     //

--- a/src/version.h
+++ b/src/version.h
@@ -18,7 +18,7 @@ static const int INIT_PROTO_VERSION = 209;
 static const int GETHEADERS_VERSION = 31800;
 
 //! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 180006;
+static const int MIN_PEER_PROTO_VERSION = 180007;
 
 //! nTime field added to CAddress, starting with this version;
 //! if possible, avoid requesting addresses nodes older than this


### PR DESCRIPTION
This pull request:
1.  Will allow nodes to invalidate alternate chain which isn't paying masternode reward.
2.  Discontinue protocol 180006 which contains masternode payment vulnerability. 